### PR TITLE
Added signup page 1 for issue #34

### DIFF
--- a/lib/pages/SignUpPageOne.dart
+++ b/lib/pages/SignUpPageOne.dart
@@ -1,0 +1,219 @@
+import 'package:chips_choice_null_safety/chips_choice_null_safety.dart';
+import 'package:flutter/material.dart';
+
+import 'package:anxiety_go/components/CustomTextField.dart';
+
+class SignUpPageOne extends StatefulWidget {
+  const SignUpPageOne({super.key});
+
+  @override
+  State<SignUpPageOne> createState() => _SignUpPageOneState();
+}
+
+class _SignUpPageOneState extends State<SignUpPageOne> {
+  final Color textColor = const Color(0xFF2C2C2C);
+  final Color chipBorderColor = const Color(0xFF7ECDAE);
+  final Color chipBackgroundColor = const Color(0xFFBCE6D7);
+  final C2ChoiceStyle chipStyle = const C2ChoiceStyle(
+    color: Color(0xFF6B6B6B),
+    backgroundColor: Color(0xFFEEEEEE),
+    borderColor: Color(0xFFEEEEEE),
+  );
+  late C2ChoiceStyle activeChipStyle = const C2ChoiceStyle(
+    color: Color(0xFF2C2C2C),
+    backgroundColor: Color(0xFFBCE6D7),
+    borderColor: Color(0xFF7ECDAE),
+    borderWidth: 3,
+    showCheckmark: false,
+  );
+
+  int agesTag = -1;
+  List<String> ageOptions = [
+    'Under 18',
+    '18 - 25',
+    '25 - 35',
+    '35 - 45',
+    '45 - 55',
+    '55+',
+  ];
+  int genderTag = -1;
+  List<String> genderOptions = [
+    'Male',
+    'Female',
+    'Nonbinary',
+  ];
+  int treatmentTag = -1;
+  List<String> treatmentOptions = [
+    'Therapy',
+    'Self Help',
+    'N/A',
+  ];
+
+  Widget _buildAgeSelection() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Age',
+          style: TextStyle(
+            fontSize: 20,
+            color: textColor,
+          ),
+        ),
+        const SizedBox(height: 10),
+        ChipsChoice<int>.single(
+          wrapped: true,
+          padding: EdgeInsets.zero,
+          value: agesTag,
+          onChanged: (val) => setState(() => agesTag = val),
+          choiceItems: C2Choice.listFrom<int, String>(
+            source: ageOptions,
+            value: (i, v) => i,
+            label: (i, v) => v,
+          ),
+          choiceStyle: chipStyle,
+          choiceActiveStyle: activeChipStyle,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildGenderSelection() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Gender',
+          style: TextStyle(
+            fontSize: 20,
+            color: textColor,
+          ),
+        ),
+        const SizedBox(height: 10),
+        ChipsChoice<int>.single(
+          wrapped: true,
+          padding: EdgeInsets.zero,
+          value: genderTag,
+          onChanged: (val) => setState(() => genderTag = val),
+          choiceItems: C2Choice.listFrom<int, String>(
+            source: genderOptions,
+            value: (i, v) => i,
+            label: (i, v) => v,
+          ),
+          choiceStyle: chipStyle,
+          choiceActiveStyle: activeChipStyle,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildOcupation() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Ocupation',
+          style: TextStyle(
+            fontSize: 20,
+            color: textColor,
+          ),
+        ),
+        const SizedBox(height: 10),
+        const CustomTextfield(), // TODO: Replace w/ component from Issue #33
+      ],
+    );
+  }
+
+  Widget _buildLocation() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Location',
+          style: TextStyle(
+            fontSize: 20,
+            color: textColor,
+          ),
+        ),
+        const SizedBox(height: 10),
+        const CustomTextfield(), // TODO: Replace w/ component from Issue #33
+      ],
+    );
+  }
+
+  Widget _buildTherapySelection() {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Are you seeking treatment for mental health?',
+          style: TextStyle(
+            fontSize: 20,
+            color: textColor,
+          ),
+        ),
+        const SizedBox(height: 10),
+        ChipsChoice<int>.single(
+          wrapped: true,
+          padding: EdgeInsets.zero,
+          value: treatmentTag,
+          onChanged: (val) => setState(() => treatmentTag = val),
+          choiceItems: C2Choice.listFrom<int, String>(
+            source: treatmentOptions,
+            value: (i, v) => i,
+            label: (i, v) => v,
+          ),
+          choiceStyle: chipStyle,
+          choiceActiveStyle: activeChipStyle,
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 15),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  width: double.infinity,
+                  child: Center(
+                    child: Text(
+                      'AnxietyGo',
+                      style: TextStyle(
+                        fontSize: 50,
+                        fontWeight: FontWeight.w700,
+                        color: textColor,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 25),
+                _buildAgeSelection(),
+                const SizedBox(height: 25),
+                _buildGenderSelection(),
+                const SizedBox(height: 25),
+                _buildOcupation(),
+                const SizedBox(height: 25),
+                _buildLocation(),
+                const SizedBox(height: 25),
+                _buildTherapySelection(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Hi @markhallak, 

I have created the page one for issue #34 . 

I split the page up into different build methods to hopefully make it easier for people find the right section and make changes in the future rather than having one big long column of parts. 
The input field for Occupation and Location doesn't seem to have been finished yet so I added the CustomTextField and a TODO to replace it. Lines 125 and 143. 

Also I assumed each of the chip selects should give you the ability to select one option. 
I also wasn't able to get the chips to be the same width, but I wasn't sure how much of an issue that would be? 
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-05 at 18 49 42](https://user-images.githubusercontent.com/52216324/222979859-093f3057-c8c4-46e1-b40f-780212ca1bea.png)
